### PR TITLE
Limit Knative scaling to 1

### DIFF
--- a/modules/cloud_run/main.tf
+++ b/modules/cloud_run/main.tf
@@ -12,6 +12,9 @@ resource "google_cloud_run_service" "cloud_run" {
     metadata {
       annotations = {
         "run.googleapis.com/cloudsql-instances" = var.sql_instance.connection_name
+
+        # No clustering (this may change for prod)
+        "autoscaling.knative.dev/maxScale" = 1
       }
     }
   }


### PR DESCRIPTION
Resolves #9 and potentially avoids costly scaling